### PR TITLE
Removes PHP warning message: OutputPage::getModuleStyles

### DIFF
--- a/cavendishmw.php
+++ b/cavendishmw.php
@@ -25,6 +25,7 @@ $wgAutoloadClasses['SkinCavendishMW'] = dirname(__FILE__).'/CavendishMW.skin.php
 $wgExtensionMessagesFiles['CavendishMW'] = dirname(__FILE__).'/CavendishMW.i18n.php';
 
 $wgResourceModules['skins.cavendishmw'] = array(
+    'position' => 'top',
     'styles' => array(
         'cavendishmw/styles/monobook.css' => array( 'media' => 'screen' ),
         'cavendishmw/styles/template.css' => array( 'media' => 'screen' ),


### PR DESCRIPTION
Correct the PHP warning "OutputPage::getModuleStyles: style module should define its position explicitly: skins.cavendishmw ResourceLoaderFileModule" in mediawiki 1.26.
